### PR TITLE
Adding build duration and more flexible messages(templates)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -9,6 +9,7 @@ The following parameters are used to configure the notification:
 Defaults to false.
 * **room_id_or_name** - The id or url encoded name of the room, valid length range: 1 - 100.
 * **auth_token** - Drone leverages the HipChat API and so it must pass an access token to authenticate correctly. If the token is not provided or invalid you will receive a 401 response.
+* **template** - Optional, supply this object to specify custom message templates.
 
 The following is a sample HipChat configuration for your .drone.yml file:
 
@@ -18,5 +19,19 @@ notify:
     from: drone
     notify: true
     room_id_or_name: 1234567
-    auth_token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    auth_token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+    template:
+      success: |
+        {{ .repo.FullName }} successfully completed for {{ .build.Number }}
+      failure: |
+        {{ .repo.FullName }} failed for {{ .build.Number }}
 ```
+
+####Available Template Variables
+* **repo** - [Drone Repo Object](https://github.com/drone/drone/blob/master/model/repo.go)
+* **build** - [Drone Build Object](https://github.com/drone/drone/blob/master/model/build.go)
+* **system** - [Drone System Object](https://github.com/drone/drone/blob/master/model/system.go)
+* **statusShoutingBold** - The build.Status converted to uppercase and surrounded by bold HTML tags
+* **statusFirstRuneUpper** - The build.Status with the first rune uppercase
+* **buildURL** - URL to the drone build
+* **buildDuration** - Time it took to complete the build. ex. 24m15s

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ This plugin is responsible for sending build notifications to your HipChat room:
       "notify": true,
       "from": "drone",
       "room_id_or_name": "1234567",
-      "auth_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      "auth_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "template": {
+        "success": "{{ .repo.FullName }} successfully completed for {{ .build.Number }}",
+        "failure": "{{ .repo.FullName }} failed for {{ .build.Number }}"
+      }
     }
 }
 EOF
@@ -76,7 +80,11 @@ docker run -i plugins/drone-hipchat <<EOF
         "notify": true,
         "from": "drone",
         "room_id_or_name": "1234567",
-        "auth_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        "auth_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "template": {
+          "success": "{{ .repo.FullName }} successfully completed for {{ .build.Number }}",
+          "failure": "{{ .repo.FullName }} failed for {{ .build.Number }}"
+        }
     }
 }
 EOF


### PR DESCRIPTION
Some teams may enjoy seeing what the commit message was, or how long the build took.
Adding these as options =) as well as turning the message into a template.

Also, I have never written in Go before, let me know what you think =)

Seeking any feedback on style, structure, variable/method names.

Thanks!
