### PR TITLE
Allow a custom server URL

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -3,6 +3,7 @@ need to supply Drone with a HipChat authentication token. You can learn more
 about authentication tokens [here](https://www.hipchat.com/docs/apiv2/auth). You
 can override the default configuration with the following parameters:
 
+* `url` - HipChat server URL, defaults to `https://api.hipchat.com`
 * `auth_token` - HipChat API token
 * `room_id_or_name` - ID or URL encoded name of the room
 * `from` - A label to be shown, defaults to `drone`

--- a/hipchat.go
+++ b/hipchat.go
@@ -8,7 +8,10 @@ import (
 	"net/http"
 )
 
-var notifyURL = "https://api.hipchat.com/v2/room/%s/notification?auth_token=%s"
+var (
+	defaultURL = "https://api.hipchat.com"
+	notifyPath = "%s/v2/room/%s/notification?auth_token=%s"
+)
 
 // Client represents the HipChat client.
 type Client struct {
@@ -24,8 +27,14 @@ type Message struct {
 }
 
 // NewClient returns a new HipChat Client.
-func NewClient(room, token string) *Client {
-	return &Client{URL: fmt.Sprintf(notifyURL, room, token)}
+func NewClient(url, room, token string) *Client {
+	if url == "" {
+		url = defaultURL
+	}
+
+	return &Client{
+		URL: fmt.Sprintf(notifyPath, url, room, token),
+	}
 }
 
 // Send takes a HipChat notification message and sends it.

--- a/main.go
+++ b/main.go
@@ -32,7 +32,11 @@ func main() {
 		vargs.Template = defaultTemplate
 	}
 
-	client := NewClient(vargs.Room.String(), vargs.Token)
+	client := NewClient(
+		vargs.URL,
+		vargs.Room.String(),
+		vargs.Token,
+	)
 
 	if err := client.Send(&Message{
 		From:   vargs.From,

--- a/main_test.go
+++ b/main_test.go
@@ -15,8 +15,11 @@ func TestClient(t *testing.T) {
 	}))
 	defer hipchat.Close()
 
-	notifyURL = hipchat.URL + "/v2/room/%s/notification?auth_token=%s"
-	client := NewClient("TheIronThrone", "xyz")
+	client := NewClient(
+		hipchat.URL,
+		"TheIronThrone",
+		"xyz",
+	)
 
 	if err := client.Send(&Message{
 		From:    "John Snow",

--- a/types.go
+++ b/types.go
@@ -7,6 +7,7 @@ import (
 // Params are the parameters that the HipChat plugin can parse.
 type Params struct {
 	Notify   bool            `json:"notify"`
+	URL      string          `json:"url"`
 	From     string          `json:"from"`
 	Room     drone.StringInt `json:"room_id_or_name"`
 	Token    string          `json:"auth_token"`


### PR DESCRIPTION
In order to allow notifications through self-hosted HipChat servers I
have integrated a new option for a custom domain which falls back to the
SaaS version of HipChat.

Fixes #15
