### PR TITLE
Add ability to use cards

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -52,10 +52,9 @@ clients support cards. The normal `template` will be used for those clients.
 
 * `use_card` - Turn on cards. Defaults to false
 * `card_icon` - Icon for card. Defaults to `http://readme.drone.io/logos/downstream.svg`
-* `card_title_template` - A plaintext only handlebars template to create a custom
-payload body. For more details take a look at the [docs](http://handlebarsjs.com/). Default used in example.
-* `card_template` - A handlebars template to create a custom payload body. For more
- details take a look at the [docs](http://handlebarsjs.com/). Default used in example.
+* `card_activity_template` - A handlebars html template to create the card activity. Default used in example.
+* `card_title_template` - A plaintext only handlebars template to create the card title Default used in example.
+* `card_desc_template` - An optional handlebars html template to create the card description. Default used in example.
 
 Example configuration that generate a custom message:
 
@@ -70,7 +69,9 @@ notify:
       <strong>{{ uppercasefirst build.status }}</strong> <a href=\"{{ system.link_url }}/{{ repo.owner }}/{{ repo.name }}/{{ build.number }}\">{{ repo.owner }}/{{ repo.name }}#{{ truncate build.commit 8 }}</a> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} </br> - {{ build.message }}
     use_card: true
     card_icon: http://readme.drone.io/logos/downstream.svg
+    card_activity_template: >
+      <a href="{{ system.link_url }}/{{ repo.owner }}/{{ repo.name }}/{{ build.number }}"><strong>{{ build.status }}</strong> {{ repo.name }} ({{ build.branch }})</a>
     card_title_template: >
-      {{ build.status }}
-    card_template: >
-     <strong>{{ repo.name }}</strong> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} <a href="{{ build.link_url }}">{{ truncate build.commit 8 }}</a> - <i>{{ build.message }}</i>
+      by {{ build.author }} in {{ duration build.started_at build.finished_at }}
+    card_desc_template: >
+      <a href="{{ build.link_url }}">{{ truncate build.commit 8 }}</a> - <i>{{ build.message }}</i>

--- a/DOCS.md
+++ b/DOCS.md
@@ -47,10 +47,13 @@ notify:
 
 ### Cards
 
-For more advanced formatting, you may want to use a hipchat card. Not all hipchat clients support cards. The normal `template` will be used for those clients.
+For more advanced formatting, you may want to use a hipchat card. Not all hipchat
+clients support cards. The normal `template` will be used for those clients.
 
 * `use_card` - Turn on cards. Defaults to false
 * `card_icon` - Icon for card. Defaults to `http://readme.drone.io/logos/downstream.svg`
+* `card_title_template` - A plaintext only handlebars template to create a custom
+payload body. For more details take a look at the [docs](http://handlebarsjs.com/). Default used in example.
 * `card_template` - A handlebars template to create a custom payload body. For more
  details take a look at the [docs](http://handlebarsjs.com/). Default used in example.
 
@@ -67,5 +70,7 @@ notify:
       <strong>{{ uppercasefirst build.status }}</strong> <a href=\"{{ system.link_url }}/{{ repo.owner }}/{{ repo.name }}/{{ build.number }}\">{{ repo.owner }}/{{ repo.name }}#{{ truncate build.commit 8 }}</a> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} </br> - {{ build.message }}
     use_card: true
     card_icon: http://readme.drone.io/logos/downstream.svg
+    card_title_template: >
+      {{ build.status }}
     card_template: >
      <strong>{{ repo.name }}</strong> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} <i>{{ build.message }}</i>

--- a/DOCS.md
+++ b/DOCS.md
@@ -73,4 +73,4 @@ notify:
     card_title_template: >
       {{ build.status }}
     card_template: >
-     <strong>{{ repo.name }}</strong> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} <i>{{ build.message }}</i>
+     <strong>{{ repo.name }}</strong> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} <a href="{{ build.link_url }}">{{ truncate build.commit 8 }}</a> - <i>{{ build.message }}</i>

--- a/DOCS.md
+++ b/DOCS.md
@@ -44,3 +44,28 @@ notify:
     template: >
       <strong>{{ uppercasefirst build.status }}</strong> <a href=\"{{ system.link_url }}/{{ repo.owner }}/{{ repo.name }}/{{ build.number }}\">{{ repo.owner }}/{{ repo.name }}#{{ truncate build.commit 8 }}</a> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} </br> - {{ build.message }}
 ```
+
+### Cards
+
+For more advanced formatting, you may want to use a hipchat card. Not all hipchat clients support cards. The normal `template` will be used for those clients.
+
+* `use_card` - Turn on cards. Defaults to false
+* `card_icon` - Icon for card. Defaults to `http://readme.drone.io/logos/downstream.svg`
+* `card_template` - A handlebars template to create a custom payload body. For more
+ details take a look at the [docs](http://handlebarsjs.com/). Default used in example.
+
+Example configuration that generate a custom message:
+
+```yaml
+notify:
+  hipchat:
+    auth_token: xxxxxxxxxxxxxxx
+    room_id_or_name: 1234567
+    from: drone
+    notify: true
+    template: >
+      <strong>{{ uppercasefirst build.status }}</strong> <a href=\"{{ system.link_url }}/{{ repo.owner }}/{{ repo.name }}/{{ build.number }}\">{{ repo.owner }}/{{ repo.name }}#{{ truncate build.commit 8 }}</a> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} </br> - {{ build.message }}
+    use_card: true
+    card_icon: http://readme.drone.io/logos/downstream.svg
+    card_template: >
+     <strong>{{ repo.name }}</strong> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} <i>{{ build.message }}</i>

--- a/hipchat.go
+++ b/hipchat.go
@@ -18,12 +18,32 @@ type Client struct {
 	URL string
 }
 
+// Icon takes an object
+type Icon struct {
+	URL string `json:"url"`
+}
+
+type Description struct {
+	Format string `json:"format"`
+	Value  string `json:"value"`
+}
+
+type Card struct {
+	ID          string      `json:"id"`
+	Style       string      `json:"style"`
+	Title       string      `json:"title"`
+	URL         string      `json:"url"`
+	Description Description `json:"description"`
+	Icon        Icon        `json:"icon"`
+}
+
 // Message represents the HipChat notification message.
 type Message struct {
 	From    string `json:"from"`
 	Color   string `json:"color"`
 	Notify  bool   `json:"notify"`
 	Message string `json:"message"`
+	Card    *Card  `json:"card,omitempty"`
 }
 
 // NewClient returns a new HipChat Client.
@@ -44,6 +64,8 @@ func (c *Client) Send(msg *Message) error {
 	if err != nil {
 		return err
 	}
+
+	fmt.Println(string(body))
 
 	buf := bytes.NewReader(body)
 	_, err = http.NewRequest("POST", c.URL, buf)

--- a/hipchat.go
+++ b/hipchat.go
@@ -18,23 +18,20 @@ type Client struct {
 	URL string
 }
 
-// Icon takes an object
-type Icon struct {
-	URL string `json:"url"`
-}
-
+// Description represents the HipChat card description
 type Description struct {
 	Format string `json:"format"`
 	Value  string `json:"value"`
 }
 
+// Card represents the HipChat card
 type Card struct {
 	ID          string      `json:"id"`
 	Style       string      `json:"style"`
 	Title       string      `json:"title"`
 	URL         string      `json:"url"`
 	Description Description `json:"description"`
-	Icon        Icon        `json:"icon"`
+	Icon        string      `json:"icon"`
 }
 
 // Message represents the HipChat notification message.

--- a/hipchat.go
+++ b/hipchat.go
@@ -62,8 +62,6 @@ func (c *Client) Send(msg *Message) error {
 		return err
 	}
 
-	fmt.Println(string(body))
-
 	buf := bytes.NewReader(body)
 	_, err = http.NewRequest("POST", c.URL, buf)
 	if err != nil {

--- a/hipchat.go
+++ b/hipchat.go
@@ -24,14 +24,22 @@ type Description struct {
 	Value  string `json:"value"`
 }
 
+// Activity represents the HipChat card activity
+type Activity struct {
+	HTML  string `json:"html"`
+	Icon  string `json:"icon,omitempty"`
+}
+
 // Card represents the HipChat card
 type Card struct {
-	ID          string      `json:"id"`
-	Style       string      `json:"style"`
-	Title       string      `json:"title"`
-	URL         string      `json:"url"`
-	Description Description `json:"description"`
-	Icon        string      `json:"icon"`
+	ID          string       `json:"id"`
+	Style       string       `json:"style"`
+	Format      string       `json:"format,omitempty"`
+	Title       string       `json:"title"`
+	URL         string       `json:"url"`
+	Icon        *string      `json:"icon,omitempty"`
+	Description *Description `json:"description,omitempty"`
+	Activity    Activity     `json:"activity,omitempty"`
 }
 
 // Message represents the HipChat notification message.

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ var (
 	buildCommit     string
 	defaultTemplate = `<strong>{{ uppercasefirst build.status }}</strong> <a href="{{ system.link_url }}/{{ repo.owner }}/{{ repo.name }}/{{ build.number }}">{{ repo.owner }}/{{ repo.name }}#{{ truncate build.commit 8 }}</a> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} </br> - {{ build.message }}`
 	defaultCardTitleTemplate = `{{ build.status }}`
-	defaultCardTemplate = `<strong>{{ repo.name }}</strong> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} <i>{{ build.message }}</i>`
+	defaultCardTemplate = `<strong>{{ repo.name }}</strong> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} <a href="{{ build.link_url }}">{{ truncate build.commit 8 }}</a> - <i>{{ build.message }}</i>`
 	defaultCardIcon = "http://readme.drone.io/logos/downstream.svg"
 )
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,8 @@ func main() {
 			ID:    build.Commit,
 			Style: "link",
 			Title: build.Status,
-			URL:   BuildTemplate(
+			Icon:  vargs.CardIcon,
+			URL: BuildTemplate(
 				&system,
 				&repo,
 				&build,
@@ -73,9 +74,6 @@ func main() {
 					&build,
 					vargs.CardTemplate,
 				),
-			},
-			Icon: Icon{
-				URL: vargs.CardIcon,
 			},
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 var (
 	buildCommit     string
 	defaultTemplate = `<strong>{{ uppercasefirst build.status }}</strong> <a href="{{ system.link_url }}/{{ repo.owner }}/{{ repo.name }}/{{ build.number }}">{{ repo.owner }}/{{ repo.name }}#{{ truncate build.commit 8 }}</a> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} </br> - {{ build.message }}`
+	defaultCardTitleTemplate = `{{ build.status }}`
 	defaultCardTemplate = `<strong>{{ repo.name }}</strong> ({{ build.branch }}) by {{ build.author }} in {{ duration build.started_at build.finished_at }} <i>{{ build.message }}</i>`
 	defaultCardIcon = "http://readme.drone.io/logos/downstream.svg"
 )
@@ -47,19 +48,29 @@ func main() {
 	}
 
 	if vargs.UseCard {
-		if len(vargs.CardTemplate) == 0 {
-			vargs.CardTemplate = defaultCardTemplate
+
+		if len(vargs.CardTitleTemplate) == 0 {
+			vargs.CardTitleTemplate = defaultCardTitleTemplate
 		}
 
 		if len(vargs.CardIcon) == 0 {
 			vargs.CardIcon = defaultCardIcon
 		}
 
+		if len(vargs.CardTemplate) == 0 {
+			vargs.CardTemplate = defaultCardTemplate
+		}
+
 		message.Card = &Card{
 			ID:    build.Commit,
 			Style: "link",
-			Title: build.Status,
 			Icon:  vargs.CardIcon,
+			Title: BuildTemplate(
+				&system,
+				&repo,
+				&build,
+				vargs.CardTitleTemplate,
+			),
 			URL: BuildTemplate(
 				&system,
 				&repo,

--- a/main_test.go
+++ b/main_test.go
@@ -31,7 +31,7 @@ func TestClient(t *testing.T) {
 	}
 }
 
-func TestBuildMessage(t *testing.T) {
+func TestBuildTemplate(t *testing.T) {
 	tests := []struct {
 		system  *drone.System
 		repo    *drone.Repo
@@ -67,7 +67,7 @@ Token: Error{"Unexpected character in expression: '}'"}`,
 	}
 
 	for _, test := range tests {
-		message := BuildMessage(test.system, test.repo, test.build, test.tmpl)
+		message := BuildTemplate(test.system, test.repo, test.build, test.tmpl)
 		if test.message != message {
 			t.Errorf("expected message:\n %s \n got message: \n %s \n", test.message, message)
 		}

--- a/types.go
+++ b/types.go
@@ -12,8 +12,8 @@ type Params struct {
 	Room              drone.StringInt `json:"room_id_or_name"`
 	Token             string          `json:"auth_token"`
 	Template          string          `json:"template"`
-    UseCard           bool            `json:"use_card"`
-    CardTitleTemplate string          `json:"card_title_template"`
-    CardTemplate      string          `json:"card_template"`
-    CardIcon          string          `json:"card_icon"`
+	UseCard           bool            `json:"use_card"`
+	CardTitleTemplate string          `json:"card_title_template"`
+	CardTemplate      string          `json:"card_template"`
+	CardIcon          string          `json:"card_icon"`
 }

--- a/types.go
+++ b/types.go
@@ -13,7 +13,8 @@ type Params struct {
 	Token             string          `json:"auth_token"`
 	Template          string          `json:"template"`
 	UseCard           bool            `json:"use_card"`
-	CardTitleTemplate string          `json:"card_title_template"`
-	CardTemplate      string          `json:"card_template"`
-	CardIcon          string          `json:"card_icon"`
+	TitleTemplate     string          `json:"card_title_template"`
+	DescTemplate      string          `json:"card_desc_template"`
+	ActivityTemplate  string          `json:"card_activity_template"`
+	Icon              string          `json:"card_icon"`
 }

--- a/types.go
+++ b/types.go
@@ -6,13 +6,14 @@ import (
 
 // Params are the parameters that the HipChat plugin can parse.
 type Params struct {
-	Notify       bool            `json:"notify"`
-	URL          string          `json:"url"`
-	From         string          `json:"from"`
-	Room         drone.StringInt `json:"room_id_or_name"`
-	Token        string          `json:"auth_token"`
-	Template     string          `json:"template"`
-    UseCard      bool            `json:"use_card"`
-    CardTemplate string          `json:"card_template"`
-    CardIcon     string          `json:"card_icon"`
+	Notify            bool            `json:"notify"`
+	URL               string          `json:"url"`
+	From              string          `json:"from"`
+	Room              drone.StringInt `json:"room_id_or_name"`
+	Token             string          `json:"auth_token"`
+	Template          string          `json:"template"`
+    UseCard           bool            `json:"use_card"`
+    CardTitleTemplate string          `json:"card_title_template"`
+    CardTemplate      string          `json:"card_template"`
+    CardIcon          string          `json:"card_icon"`
 }

--- a/types.go
+++ b/types.go
@@ -6,10 +6,13 @@ import (
 
 // Params are the parameters that the HipChat plugin can parse.
 type Params struct {
-	Notify   bool            `json:"notify"`
-	URL      string          `json:"url"`
-	From     string          `json:"from"`
-	Room     drone.StringInt `json:"room_id_or_name"`
-	Token    string          `json:"auth_token"`
-	Template string          `json:"template"`
+	Notify       bool            `json:"notify"`
+	URL          string          `json:"url"`
+	From         string          `json:"from"`
+	Room         drone.StringInt `json:"room_id_or_name"`
+	Token        string          `json:"auth_token"`
+	Template     string          `json:"template"`
+    UseCard      bool            `json:"use_card"`
+    CardTemplate string          `json:"card_template"`
+    CardIcon     string          `json:"card_icon"`
 }


### PR DESCRIPTION
This adds rudimentary support for hipchat cards.  Cards are much more extensible than the basic message format.

This maintains legacy behavior by default.

Here is the normal message, a collapsed card, an expanded card, and a collapsed failure:
<img width="735" alt="screen shot 2016-05-01 at 10 52 42 am" src="https://cloud.githubusercontent.com/assets/7569921/14942433/09105a64-0f8b-11e6-8d31-be9da948a5db.png">
